### PR TITLE
Add separated “Break” key and functional keys

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,4 +1,5 @@
 var keyCodes = {
+   3 : "break",
    8 : "backspace / delete",
    9 : "tab",
    12 : 'clear',
@@ -99,6 +100,12 @@ var keyCodes = {
    130 : "f19",
    144 : "num lock ",
    145 : "scroll lock",
+   173 : "mute/unmute",
+   174 : "decrease volume level",
+   175 : "increase volume level",
+   181 : "mute/unmute (firefox)",
+   182 : "decrease volume level (firefox)",
+   183 : "increase volume level (firefox)",
    186 : "semi-colon ",
    187 : "equal sign ",
    188 : "comma",
@@ -111,7 +118,8 @@ var keyCodes = {
    221 : "close bracket ",
    222 : "single quote ",
    224 : "left or right ⌘ key (firefox)",
-   225 : "altgr"
+   225 : "altgr",
+   255 : "toggle touchpad"
 }
 
 $(function(){


### PR DESCRIPTION
The keycodes were generated on a Lenovo laptop in Windows 8.1. Tested in Chrome, Firefox and IE.