### PR TITLE
Page Forward Key

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -109,6 +109,7 @@ var keyCodes = {
   145 : "scroll lock",
   160 : "^",
   163 : "#",
+  167 : "page forward (Chromebook)"
   173 : "minus (firefox), mute/unmute",
   174 : "decrease volume level",
   175 : "increase volume level",


### PR DESCRIPTION
Dunno whether it's just for Chromebook or for any keyboard/computer with a page-forward key. I can't get any of the other CHromebook function keys because they actually do stuff and don't show a code.