### PR TITLE
fix breaking bug

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -109,7 +109,7 @@ var keyCodes = {
   145 : "scroll lock",
   160 : "^",
   163 : "#",
-  167 : "page forward (Chromebook)"
+  167 : "page forward (Chromebook)",
   173 : "minus (firefox), mute/unmute",
   174 : "decrease volume level",
   175 : "increase volume level",


### PR DESCRIPTION
The keycodes map was had a comma missing on line 112, and the site was broken. Fixed by adding a comma.