### PR TITLE
Added keyCode '0' I found while using aWindows-oriented keyboard on OS X.

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var keyCodes = {
+  0 : "Windows Menu (Windows-oriented keyboard used on Mac)",
   3 : "break",
   8 : "backspace / delete",
   9 : "tab",


### PR DESCRIPTION
I found your website and tried all keys on the keyboard until I reached the Menu button. On Windows it returns 93 but on my Macbook it returns the _missing keycode_ message. Hope this helps!