### PR TITLE
Adding SHIFT pressed keys

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -158,17 +158,64 @@ var keyCodes = {
   255 : "toggle touchpad"
 };
 
+var keyCodesShift = {
+  188 : [60 , '<'],
+  49 : [33 , '!'],
+  222 : [34 , '"'],
+  51 : [35 , '#'],
+  52 : [36 , '$'],
+  53 : [37 , '%'],
+  55 : [38 , '&'],
+  57 : [40 , '('],
+  48 : [41 , ')'],
+  56 : [42 , '*'],
+  189 : [43 , '+'],
+  186 : [58 , ':'],
+  60 : [60 , '<'],
+  190 : [62 , '>'],
+  191 : [63 , '?'],
+  50 : [64 , '@'],
+  54 : [94 , '^'],
+  189 : [95 , '_'],
+  219 : [123 , '{'],
+  220 : [124 , '|'],
+  221 : [125 , '}'],
+  192 : [126 , '~']
+};
+
+var keyCodesAlt = {
+  67 : [131 , 'ç']
+};
+
 var body = document.querySelector('body');
 
 body.onkeydown = function (e) {
+
   if ( !e.metaKey ) {
     e.preventDefault();
   }
 
-  document.querySelector('.keycode-display').innerHTML = e.keyCode;
+  var code = e.keyCode,
+      display = keyCodes[e.keyCode],
+      prefix = '';
+
+  if (e.shiftKey && keyCodesShift[e.keyCode]) {
+    code = keyCodesShift[e.keyCode][0];
+    display = keyCodesShift[e.keyCode][1];
+    prefix = 'shift + ';
+  }
+
+  if (e.altKey && keyCodesAlt[e.keyCode]) {
+    code = keyCodesAlt[e.keyCode][0];
+    display = keyCodesAlt[e.keyCode][1];
+    prefix = 'alt + ';
+  }
+
+  document.querySelector('.keycode-display').innerHTML = code;
   document.querySelector('.text-display').innerHTML =
-    keyCodes[e.keyCode] || `huh? Let me know what browser and key this was. <a href='https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!'>Submit to Github</a>`;
-};
+    display ? (prefix + display) : `huh? Let me know what browser and key this was. <a href='https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!'>Submit to Github</a>`;
+
+}
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/scripts.js
+++ b/scripts.js
@@ -190,7 +190,6 @@ var keyCodesAlt = {
 var body = document.querySelector('body');
 
 body.onkeydown = function (e) {
-
   if ( !e.metaKey ) {
     e.preventDefault();
   }
@@ -214,8 +213,7 @@ body.onkeydown = function (e) {
   document.querySelector('.keycode-display').innerHTML = code;
   document.querySelector('.text-display').innerHTML =
     display ? (prefix + display) : `huh? Let me know what browser and key this was. <a href='https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!'>Submit to Github</a>`;
-
-}
+};
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
I've added the ability to see keys with `shift` and `alt` pressed.
The idea is to create an array for the `shift` keys and another for the `alt` keys.
To get the specific code it needs for use `onkeypress`, instead of `onkeydown`.

Please feel free to ignore it or use some parts of it.

Thanks the project. Quite useful.

Cheers,
Danilo
