### PR TITLE
added ç to keycodes

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -153,6 +153,7 @@ var keyCodes = {
   225 : "altgr",
   226 : "< /git >",
   230 : "GNOME Compose Key",
+  231 : "ç",
   233 : "XF86Forward",
   234 : "XF86Back",
   255 : "toggle touchpad"


### PR DESCRIPTION
**Added 'ç' key.** 

A very common in Brazilian Portuguese. It is the right key after _'L' in the ABNT2 keyboard._