### PR TITLE
[FIX] correctly add e.keyCode to issue URL.

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -167,7 +167,6 @@ body.onkeydown = function (e) {
   }
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
-  console.log("huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>");
   document.querySelector('.text-display').innerHTML =
     keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
 };

--- a/scripts.js
+++ b/scripts.js
@@ -167,8 +167,9 @@ body.onkeydown = function (e) {
   }
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
+  console.log("huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>");
   document.querySelector('.text-display').innerHTML =
-    keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
+    keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
 };
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This commit fixes the `e.keyCode` variable inside the "Submit to GitHub" link for keys which could not be found. 

Issue: #163