### PR TITLE
Display the JSON of the event itself.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
       <p class="keycode-display"></p>
-      <pre class="event-display">
+      <pre>
         <code id="keyboard-event">
         </code>
       </pre>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
       <p class="keycode-display"></p>
+      <pre class="event-display">
+        <code id="keyboard-event">
+        </code>
+      </pre>
       <p class="text-display">press any key to get the JavaScript event keycode</p>
     </div>
   </div>

--- a/scripts.js
+++ b/scripts.js
@@ -174,10 +174,10 @@ body.onkeydown = function (e) {
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
   document.querySelector('#keyboard-event').innerHTML = JSON.stringify({
-    code: e.code,
-    key: e.key,
-    keyCode: e.keyCode,
-    which: e.which
+    code: e.code || null,
+    key: e.key || null,
+    keyCode: e.keyCode || null,
+    which: e.which || null
   }).replace('{', '{ ')
     .replace(/,/g, ', ')
     .replace(/:/g, ': ')

--- a/scripts.js
+++ b/scripts.js
@@ -173,8 +173,19 @@ body.onkeydown = function (e) {
   }
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
-  document.querySelector('.text-display').innerHTML =
+  document.querySelector('#keyboard-event').innerHTML = JSON.stringify({
+    code: e.code,
+    key: e.key,
+    keyCode: e.keyCode,
+    which: e.which
+  }).replace('{', '{ ')
+    .replace(/,/g, ', ')
+    .replace(/:/g, ': ')
+    .replace('}', ' }');
+  document.querySelector('text-display').innerHTML =
     keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
+
+  console.dir(e);
 };
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/scripts.js
+++ b/scripts.js
@@ -182,10 +182,8 @@ body.onkeydown = function (e) {
     .replace(/,/g, ', ')
     .replace(/:/g, ': ')
     .replace('}', ' }');
-  document.querySelector('text-display').innerHTML =
+  document.querySelector('.text-display').innerHTML =
     keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
-
-  console.dir(e);
 };
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/style.css
+++ b/style.css
@@ -4,29 +4,33 @@
   	padding: 0;
   }
 
-  html,body {
+  html, body {
     height:100%;
     margin:0;
     font-family: 'Montserrat', 'sans-serif';
     color:#424242;
     overflow: hidden;
   }
+
   .display {
     text-align: center;
     display: table;
     height:100%;
     margin:0 auto;
   }
+
   .wrap {
     display: table-cell;
     vertical-align: middle;
   }
+
   p {
     font-size: 100px; /* For lamers who don't support viewport sizing */
     font-size:40vmin;
     text-align: center;
     margin: 0;
   }
+
   p.text-display {
     display: inline-block;
     color: #5E5E5E;
@@ -49,13 +53,16 @@
     width: 100%;
     text-align: center;
   }
+
   span.love a {
     text-decoration: none;
     color:#D12026;
   }
+
   .twitter-follow-button {
     vertical-align: text-bottom;
   }
+
   .twitter-share-button {
     vertical-align: text-bottom;
   }

--- a/style.css
+++ b/style.css
@@ -4,33 +4,29 @@
   	padding: 0;
   }
 
-  html, body {
+  html,body {
     height:100%;
     margin:0;
     font-family: 'Montserrat', 'sans-serif';
     color:#424242;
     overflow: hidden;
   }
-
   .display {
     text-align: center;
     display: table;
     height:100%;
     margin:0 auto;
   }
-
   .wrap {
     display: table-cell;
     vertical-align: middle;
   }
-
   p {
     font-size: 100px; /* For lamers who don't support viewport sizing */
     font-size:40vmin;
     text-align: center;
     margin: 0;
   }
-
   p.text-display {
     display: inline-block;
     color: #5E5E5E;
@@ -53,16 +49,13 @@
     width: 100%;
     text-align: center;
   }
-
   span.love a {
     text-decoration: none;
     color:#D12026;
   }
-
   .twitter-follow-button {
     vertical-align: text-bottom;
   }
-
   .twitter-share-button {
     vertical-align: text-bottom;
   }


### PR DESCRIPTION
@wesbos not sure if you're into the updated UX, but from a usefulness standpoint this is super critical for the general developer. I've seen a lot of confusion about which browsers support `which` vs. `keyCode` vs. `key` vs `code`. 

Depending on what keys you are consuming in your app / component `key` or `code` can be used, but become unruly for things like `Space`. e.g. 

<img width="790" alt="screen shot 2017-07-07 at 12 22 59 am" src="https://user-images.githubusercontent.com/4624/27943110-7678fc6e-62aa-11e7-996d-400aa2635470.png">
