### PR TITLE
Adds some code to show the DOM3 Keyboard `event.key` value

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
       <p class="keycode-display"></p>
+      <p class="key-display"></p>
       <p class="text-display">press any key to get the JavaScript event keycode</p>
     </div>
   </div>

--- a/scripts.js
+++ b/scripts.js
@@ -173,6 +173,7 @@ body.onkeydown = function (e) {
   }
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
+  document.querySelector('.key-display').innerHTML = 'DOM3 Key: ' + e.key;
   document.querySelector('.text-display').innerHTML =
     keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
 };

--- a/style.css
+++ b/style.css
@@ -41,7 +41,9 @@
     box-shadow: inset 0 0 25px #E8E8E8, 0 1px 0 #C3C3C3, 0 2px 0 #C9C9C9, 0 2px 3px #333;
     text-shadow: 0px 1px 0px #F5F5F5;
   }
-
+  .key-display {
+    font-size: 40px;
+  }
   span.love {
     display: block;
     position: absolute;


### PR DESCRIPTION
DOM 3 Events have `event.key` which is a string representation of the value. This adds that to the page.

![key](https://user-images.githubusercontent.com/118266/28163652-f63b0b68-67c3-11e7-8afa-b538f900c933.gif)
