### PR TITLE
Add key display; console logging

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -181,7 +181,8 @@ body.onkeydown = function (e) {
 
   document.querySelector('.keycode-display').innerHTML = e.keyCode;
   document.querySelector('.text-display').innerHTML =
-    keyCodes[e.keyCode] || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
+    keyCodes[e.keyCode] + (keyCodes[e.keyCode] !== e.key ? ' (' + e.key + ')' : '') || "huh? Let me know what browser and key this was. <a href=\"https://github.com/wesbos/keycodes/issues/new?title=Missing keycode "+e.keyCode+"&body=Tell me what key it was or even better, submit a Pull request!\">Submit to Github</a>";
+  console.log('event.which: ' + e.which + '; event.keyCode: ' + e.keyCode + '; event.key: ' + e.key + ';');
 };
 
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
If the key hit is different than the text description, displays the key
in parentheses next to the textual description.