### PR TITLE
Fixed #239 by adding quotes around the keyCode representation

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -212,7 +212,7 @@ body.onkeydown = function(e) {
   if (e.key != null && e.key === 'Unidentified'){
     newKeyText = `<a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Special_values" target="_blank">Unidentified</a>`;
   } else {
-    newKeyText = e.key || '';
+    newKeyText = `"<span>${e.key}</span>"` || '';
   }
 
   // Check if code is Unidentified then redirect to docs

--- a/style.css
+++ b/style.css
@@ -118,6 +118,15 @@
   min-height: 35px;
 }
 
+.card.item-key .main-description {
+  color: #CCC;
+}
+
+.card.item-key .main-description span {
+  color: initial;
+}
+
+
 @media (min-width: 601px) and (max-width: 980px) {
   body{
     overflow-y: auto;


### PR DESCRIPTION
Added quotes around keyCode representation. This is consistent with how MDN represents the values on [their page](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). It also indicates that the value received is a string.

To avoid confusion when representing the actual quote character, I "dimmed" the quotes a bit so they don't get in the way.

Please let me know if the use of template literals is acceptable here, i.e. if Internet Explorer should be supported or not.

![2018-08-22_13-44-59](https://user-images.githubusercontent.com/793221/44461560-a5bbc000-a611-11e8-9995-93b1a0a62884.gif)
