### PR TITLE
changed http:// to https to prevent mixed content

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>JavaScript Event KeyCodes</title>
-  <link href='http://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Montserrat' rel='stylesheet' type='text/css'>
   <meta name="viewport" content="width=device-width, user-scalable=no">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="JavaScript Event KeyCodes">


### PR DESCRIPTION
While visiting **https://**keycode.info/ i noticed fonts didn't load after taking a look into my devtools i noticed there was mixed content because of a font url prefixed with http:// so pretty much changed this url to https