### PR TITLE
Make links explicitly HTTPS and add the 'rel' attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,13 +45,13 @@
   </div>
 
   <span class="love">Made with love by
-    <a href="http://wesbos.com" target="_blank">Wes Bos</a> — fork or suggest edits on
-    <a href="http://github.com/wesbos/keycodes" target="_blank">GitHub</a> —
+    <a href="https://wesbos.com" target="_blank" rel="noopener">Wes Bos</a> — fork or suggest edits on
+    <a href="https://github.com/wesbos/keycodes" target="_blank" rel="noopener">GitHub</a> —
 
-    <a href="https://twitter.com/wesbos" class="twitter-follow-button" data-show-count="false" target="_blank">Follow @wesbos</a>
+    <a href="https://twitter.com/wesbos" class="twitter-follow-button" data-show-count="false" target="_blank" rel="noopener">Follow @wesbos</a>
 
-    <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://keycode.info" data-text="Nice tool for finding JavaScript event keycodes"
-      data-via="wesbos" data-related="wesbos" target="_blank">Tweet</a>
+    <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://keycode.info" data-text="Nice tool for finding JavaScript event keycodes"
+      data-via="wesbos" data-related="wesbos" target="_blank" rel="noopener">Tweet</a>
 
 
   </span>


### PR DESCRIPTION
Changed over the links to use HTTP**S** rather than HTTP as I noticed that GitHub pages don't automatically redirect to secure so probably better to be explicit.

Also added the `rel="noopener"` attribute to the links for additional cross origin best practice. Ups the Lighthouse score slightly.