### PR TITLE
Allow use on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
       <div class="hidden_input-container" aria-hidden="true">
-        <input id="hidden_input" type="text" autocorrect="off" autocapitalize="off">
+        <input id="hidden_input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
       </div>
       <p class="keycode-display"></p>
       <p class="text-display">Press any key to get the JavaScript event keycode</p>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <meta name="twitter:description" content="Keycode testing tool - which keys map to which keycodes?">
   <meta name="twitter:creator" content="@wesbos">
   <meta name="twitter:image" content="http://f.cl.ly/items/1Z3e0c1R36001s1D271A/ss%202014-04-28%20at%2012.08.06%20PM.png">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=20181010">
   <link rel="icon" href="">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
   <canvas width="128" height="128" hidden></canvas>
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
+      <div class="hidden_input-container" aria-hidden="true">
+        <input id="input" type="text" autocorrect="off" autocapitalize="off">
+      </div>
       <p class="keycode-display"></p>
       <p class="text-display">Press any key to get the JavaScript event keycode</p>
       <div class="cards hide">
@@ -31,7 +34,8 @@
         <div class="card item-which">
           <div class="card-header">
             event.which
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent" target="_blank" rel="noopener" class="deprecated-link">(deprecated)</a>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent" target="_blank" rel="noopener"
+              class="deprecated-link">(deprecated)</a>
           </div>
           <div class="card-main">
             <div class="main-description">which</div>
@@ -51,7 +55,8 @@
     <a href="https://wesbos.com" target="_blank" rel="noopener">Wes Bos</a> — fork or suggest edits on
     <a href="https://github.com/wesbos/keycodes" target="_blank" rel="noopener">GitHub</a> —
 
-    <a href="https://twitter.com/wesbos" class="twitter-follow-button" data-show-count="false" target="_blank" rel="noopener">Follow @wesbos</a>
+    <a href="https://twitter.com/wesbos" class="twitter-follow-button" data-show-count="false" target="_blank" rel="noopener">Follow
+      @wesbos</a>
 
     <a href="https://twitter.com/share" class="twitter-share-button" data-url="https://keycode.info" data-text="Nice tool for finding JavaScript event keycodes"
       data-via="wesbos" data-related="wesbos" target="_blank" rel="noopener">Tweet</a>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       navigator.serviceWorker.register('./service-worker.js');
     }
   </script>
-  <script src="scripts.js"></script>
+  <script src="scripts.js?v=20181010"></script>
   <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https'; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + '://platform.twitter.com/widgets.js'; fjs.parentNode.insertBefore(js, fjs); } }(document, 'script', 'twitter-wjs');</script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div class="display">
     <div class="wrap" aria-live="polite" aria-atomic="true">
       <div class="hidden_input-container" aria-hidden="true">
-        <input id="input" type="text" autocorrect="off" autocapitalize="off">
+        <input id="hidden_input" type="text" autocorrect="off" autocapitalize="off">
       </div>
       <p class="keycode-display"></p>
       <p class="text-display">Press any key to get the JavaScript event keycode</p>

--- a/scripts.js
+++ b/scripts.js
@@ -174,6 +174,8 @@ const keyCodes = {
 };
 
 const body = document.querySelector('body');
+const hiddenInput = document.getElementById('hidden_input');
+const isAndroid = navigator.userAgent.match(/Android/i);
 
 const canvas = document.querySelector('canvas');
 const ctx = canvas.getContext('2d');
@@ -192,14 +194,42 @@ function drawNumberToCanvas(number) {
   link.href = data;
 }
 
-body.onkeydown = function(e) {
+function getLastCharFromString(str) {
+  return str[str.length - 1];
+}
+function getLastCharCodeFromString(str) {
+  return str.charCodeAt(str.length-1);
+}
+
+body.onkeyup = function(e) {
   if (!e.metaKey) {
     e.preventDefault();
+  } 
+  
+  var charKeyCode = e.keyCode;
+  var newKeyText = '';
+
+  //for android chrome keycode fix
+  if (isAndroid && e.keyCode == 229 && hiddenInput.value.length>0) {
+    charKeyCode = getLastCharCodeFromString(hiddenInput.value);
+    newKeyText = getLastCharFromString(hiddenInput.value);
+
+    hiddenInput.value = '';
+    hiddenInput.blur();
+  } else {
+    // Check if Key_Values is Unidentified then redirect to docs
+    if (e.key != null && e.key === 'Unidentified') {
+      newKeyText = '<a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Special_values" target="_blank">Unidentified</a>';
+    } else if (e.key == ' ') {
+      newKeyText = `<span class="text-muted">(Space character)</span>`;
+    } else {
+      newKeyText = e.key || '';
+    }
   }
-  drawNumberToCanvas(e.keyCode);
+  drawNumberToCanvas(charKeyCode);
 
   // Main e.keyCode display
-  document.querySelector('.keycode-display').innerHTML = e.keyCode;
+  document.querySelector('.keycode-display').innerHTML = charKeyCode;
 
   // Show the cards with all
   var cards = document.querySelector('.cards');
@@ -207,15 +237,6 @@ body.onkeydown = function(e) {
   cards.classList.remove('hide');
   document.querySelector('.text-display').classList.add('hide');
 
-  // Check if Key_Values is Unidentified then redirect to docs
-  var newKeyText = '';
-  if (e.key != null && e.key === 'Unidentified'){
-    newKeyText = '<a href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Special_values" target="_blank">Unidentified</a>';
-  } else if (e.key == ' '){
-    newKeyText = `<span class="text-muted">(Space character)</span>`;
-  } else {
-    newKeyText = e.key || '';
-  }
 
   // Check if code is Unidentified then redirect to docs
   var newCodeText = '';
@@ -226,7 +247,7 @@ body.onkeydown = function(e) {
   }
 
   document.querySelector('.item-key .main-description').innerHTML = newKeyText;
-  document.querySelector('.item-which .main-description').innerHTML = e.which || '';
+  document.querySelector('.item-which .main-description').innerHTML = charKeyCode || '';
   document.querySelector('.item-code .main-description').innerHTML = newCodeText;
 
   // document.querySelector('.text-display').innerHTML =
@@ -234,9 +255,20 @@ body.onkeydown = function(e) {
   //   `huh? Let me know what browser and key this was. <a href="https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!">Submit to Github</a>`;
 };
 
-body.addEventListener('touchend', function() {
-  document.getElementById('hidden_input').focus();
-}, true);
+function focusHiddenInput() {
+
+  if (isAndroid) {
+    setTimeout(function () {
+      hiddenInput.focus();
+      hiddenInput.click();
+    }, 100);
+  } else {
+    hiddenInput.focus();
+  }
+}
+
+body.addEventListener('touchend', focusHiddenInput, true);
+
 
 (function(i, s, o, g, r, a, m) {
   i.GoogleAnalyticsObject = r;

--- a/scripts.js
+++ b/scripts.js
@@ -234,6 +234,10 @@ body.onkeydown = function(e) {
   //   `huh? Let me know what browser and key this was. <a href="https://github.com/wesbos/keycodes/issues/new?title=Missing keycode ${e.keyCode}&body=Tell me what key it was or even better, submit a Pull request!">Submit to Github</a>`;
 };
 
+body.addEventListener('touchend', function() {
+  document.getElementById('hidden_input').focus();
+}, true);
+
 (function(i, s, o, g, r, a, m) {
   i.GoogleAnalyticsObject = r;
   (i[r] =

--- a/style.css
+++ b/style.css
@@ -23,6 +23,13 @@
     display: table-cell;
     vertical-align: middle;
   }
+  .hidden_input-container {
+    position: relative;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    left: -2000px;
+  }
   p {
     font-size: 100px; /* For lamers who don't support viewport sizing */
     font-size:40vmin;

--- a/style.css
+++ b/style.css
@@ -56,9 +56,13 @@
   span.love {
     display: block;
     position: absolute;
-    bottom:10px;
+    background-color: #f2f4f8;
+    bottom: 0px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     width: 100%;
     text-align: center;
+    min-height: 40px;
   }
   span.love a {
     text-decoration: none;


### PR DESCRIPTION
allows a user to tap anywhere on the page; this will set focus to a hidden input, which in turn opens the soft keyboard. Tested on iOS & Android