### PR TITLE
Add airplane mode key under Ubuntu

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -119,6 +119,7 @@ const keyCodes = {
   135: 'f24',
   144: 'num lock',
   145: 'scroll lock',
+  151: 'airplane mode',
   160: '^',
   161: '!',
   162: '؛ (arabic semicolon)',


### PR DESCRIPTION
At the moment, when pressing the airplane button on my keyboard on my Ubuntu laptop, the browser receives the following key presses in quick succession (less than 0.25s apart): 

```
{
  "which": 151,
  "key": "Unidentified",
  "code": ""
}
{
  "which": 0,
  "key": "Unidentified",
  "code": ""
}
```

While the last event doesn't have a proper key, the first one does, so I mapped that key to the airplane mode

PS: this was hard to test because I kept losing internet, :-P