### PR TITLE
Improvement: Set query params for unique URL <-> key mapping

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -267,9 +267,19 @@ body.onkeydown = function(e) {
     mobileInput.value = '';
   }
 
+  // Use either which or keyCode, depending on browser support
+  const newKeyWhichText = e.which || e.keyCode || '';
+
   document.querySelector('.item-key .main-description').innerHTML = newKeyText;
-  document.querySelector('.item-which .main-description').innerHTML = e.which || '';
+  document.querySelector('.item-which .main-description').innerHTML = newKeyWhichText;
   document.querySelector('.item-code .main-description').innerHTML = newCodeText;
+
+  // Set query param, so that this URL leads to exactly this keypress
+  window.history.pushState(
+    {}, 
+    newCodeText, 
+    `?key=${newKeyText}&code=${newCodeText}&which=${newKeyWhichText}`
+  );
 
   // document.querySelector('.text-display').innerHTML =
   //   keyCodes[e.keyCode] ||
@@ -293,4 +303,22 @@ body.onkeydown = function(e) {
 ga('create', 'UA-50371747-1', 'keycode.info');
 ga('send', 'pageview');
 
-drawNumberToCanvas('⌨️');
+// Simulate a key press based on query params or show default icon
+const urlParams = new URLSearchParams(window.location.search);
+const keyParam = urlParams.get('key');
+const codeParam = urlParams.get('code');
+const whichParam = urlParams.get('which');
+
+if (keyParam && codeParam && whichParam) {
+  // Simulate key press to use existing logic for showing key in ui
+  var keyboardEvent = new KeyboardEvent('keydown', {
+    key: keyParam,
+    code: codeParam,
+    which: whichParam,
+    keyCode: whichParam
+  });
+  body.dispatchEvent(keyboardEvent);
+} else {
+  // Show default icon for fresh start
+  drawNumberToCanvas('⌨️');
+}


### PR DESCRIPTION
This will create a URL like `https://keycode.info/?key=h&code=KeyH&which=72` after e.g. pressing "h".

I thought this might be cool to quickly generate a unique link for each key to share with other people.

To use existing UI logic, I simulate a keydown event on page load if query params exist.

PS: Doing this after listening to the [Hacktoberfest hasty treat on syntax.fm](https://syntax.fm/show/081/hasty-treat-hacktoberfest). Thanks for the motivation Wes & Scott!!