### PR TITLE
Change table mode headings to reflect contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
     <table class="table hide">
       <thead>
         <tr>
-          <th>Key</th>
           <th>Key Code</th>
+          <th>Key</th>
         </tr>
       </thead>
       <tbody class="table-body">


### PR DESCRIPTION
Currently the headings for table view are back to front, with "Key" being the code and "Key Code" being the key alone. This change brings them into line, though perhaps you'd prefer to alter the table population in scripts.js so the key td is written first.