### PR TITLE
Update to CACHE_NAME

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,7 @@
  * The name of the current cache
  * @type {String}
  */
-const CACHE_NAME = 'v1';
+const CACHE_NAME = 'v2';
 
 /**
  * Files to cache


### PR DESCRIPTION
Old service worker is returning older index.html scaffold, and this is breaking script.

This PR updates to the CACHE_NAME to invalidate the old cache.