### PR TITLE
Prevent Table from cutting off

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,7 +42,8 @@ p.text-display {
   background: #fbfbfb;
   border-radius: 4px;
   border-top: 1px solid #dadada;
-  box-shadow: inset 0 0 25px #e8e8e8, 0 1px 0 #c3c3c3, 0 2px 0 #c9c9c9, 0 2px 3px #333;
+  box-shadow: inset 0 0 25px #e8e8e8, 0 1px 0 #c3c3c3, 0 2px 0 #c9c9c9,
+    0 2px 3px #333;
   text-shadow: 0px 1px 0px #f5f5f5;
   min-width: 24px;
   font-size: 26px;
@@ -116,7 +117,8 @@ span.love a {
 .card:hover {
   cursor: pointer;
   transform: translateY(-5px) scale(1.005) translateZ(0);
-  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.11), 0 24px 46px rgba(220, 233, 255, 0.48);
+  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.11),
+    0 24px 46px rgba(220, 233, 255, 0.48);
 }
 
 .card-header {
@@ -170,7 +172,7 @@ span.love a {
   width: 50%;
   table-layout: fixed;
   margin: auto;
-  margin-top: 75px;
+  margin-top: 5vh;
   box-shadow: 0 14px 26px rgba(0, 0, 0, 0.04);
   border-radius: 5px;
   border-collapse: collapse;
@@ -180,7 +182,7 @@ span.love a {
   display: block;
   width: 100%;
   overflow: auto;
-  height: 600px;
+  height: 77vh;
   background: #fff;
 }
 
@@ -229,7 +231,8 @@ span.love a {
 
 .table-toggle-button:hover {
   transform: translateY(-2px) scale(1.005) translateZ(0);
-  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.11), 0 6px 9px rgba(220, 233, 255, 0.48);
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.11),
+    0 6px 9px rgba(220, 233, 255, 0.48);
 }
 
 .table-toggle-button:active {
@@ -251,7 +254,8 @@ span.love a {
 .mobile-input input:focus {
   outline: none;
   transform: translateY(-5px) scale(1.005) translateZ(0);
-  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.11), 0 24px 46px rgba(220, 233, 255, 0.48);
+  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.11),
+    0 24px 46px rgba(220, 233, 255, 0.48);
 }
 
 @media (min-width: 601px) and (max-width: 980px) {


### PR DESCRIPTION
I noticed the "Table" view table was overflowing the bottom of my screen (13" macbook pro) and some of the content was not viewable. I updated the fixed height of the `tbody` from 600px -> 77vh, and I also updated the `margin-top` of the entire table from 75px -> 5vh. 

(some of the box-shadows were also put on 2 lines due to my prettier plugin; this was unintentional 😅)