### PR TITLE
Update to CACHE_NAME

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta name="twitter:description" content="Keycode testing tool - which keys map to which keycodes?">
   <meta name="twitter:creator" content="@wesbos">
   <meta name="twitter:image" content="https://cdn1.imggmi.com/uploads/2019/7/12/f6b03f5628f7850649714200ab517a52-full.png">
-  <link rel="stylesheet" href="style.css?v=06272019">
+  <link rel="stylesheet" href="style.css?v=10122019">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.css" />
   <link rel="icon" href="">
 </head>

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,7 @@
  * The name of the current cache
  * @type {String}
  */
-const CACHE_NAME = 'v3';
+const CACHE_NAME = 'v4';
 
 /**
  * Files to cache


### PR DESCRIPTION
The old service worker is returning older index.html scaffold, and this is not loading the latest CSS changes.

This PR updates to the CACHE_NAME to invalidate the old cache.