### PR TITLE
Removed outline of all elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,9 @@ body {
   overflow: hidden;
   background: var(--background);
 }
+* {
+  outline: none;
+}
 .display {
   text-align: center;
   display: table;


### PR DESCRIPTION
Tab key is unused to navigate on this site, and outline would not be necessary.