### PR TITLE
Keycodes History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .DS_Store
 .next/
+.idea/

--- a/lib/urlFriendly.js
+++ b/lib/urlFriendly.js
@@ -11,6 +11,8 @@ export function urlFriendly(key) {
     case '.':
       // period
       return '190';
+    case '/':
+      return '191';
     default:
       break;
   }

--- a/lib/useKeyCode.js
+++ b/lib/useKeyCode.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { useKeyCode } from '../components/KeyCodeProvider';
 import { urlFriendly } from './urlFriendly';
@@ -7,8 +7,9 @@ export function useKeyWatcher() {
   // const [key, setKey] = useState();
   const { key, setKey, setEvents, events, setKeyHistory } = useKeyCode();
   const router = useRouter();
-  useEffect(() => {
-    window.addEventListener('keydown', function (e) {
+
+  const handleKeyDown = useCallback(
+    (e) => {
       e.preventDefault();
       router.push(`/for/${urlFriendly(e.key)}`);
       const generatedKey = {
@@ -45,12 +46,18 @@ export function useKeyWatcher() {
       // this is bad, but making a copy didn't work for some reason
       events[generatedKey.keyCode] = generatedKey;
       setEvents(events);
-    });
+    },
+    [events, router, setEvents, setKey, setKeyHistory]
+  );
 
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
-      // remove event listner
+      // remove event listener
+      window.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [handleKeyDown]);
+
   return {
     key,
     events,

--- a/lib/useKeyCode.js
+++ b/lib/useKeyCode.js
@@ -5,20 +5,13 @@ import { urlFriendly } from './urlFriendly';
 
 export function useKeyWatcher() {
   // const [key, setKey] = useState();
-  const {
-    key,
-    setKey,
-    setEvents,
-    events,
-    setKeyHistory,
-    keyHistory,
-  } = useKeyCode();
+  const { key, setKey, setEvents, events, setKeyHistory } = useKeyCode();
   const router = useRouter();
   useEffect(() => {
     window.addEventListener('keydown', function (e) {
       e.preventDefault();
       router.push(`/for/${urlFriendly(e.key)}`);
-      const key = {
+      const generatedKey = {
         key: e.key,
         keyCode: e.keyCode,
         which: e.which,
@@ -31,10 +24,26 @@ export function useKeyWatcher() {
         shiftKey: e.shiftKey,
         repeat: e.repeat,
       };
-      setKey(key);
-      // setKeyHistory([key, ...keyHistory]);
+      setKey(generatedKey);
+      setKeyHistory((prevState) => {
+        if (prevState.length === 0) return [generatedKey];
+
+        const isDuplicate = prevState.some(
+          (prevKey) => prevKey.key === generatedKey.key
+        );
+
+        if (isDuplicate) return prevState;
+
+        // Add a max. of 4 items in the history
+        if (prevState.length === 4) {
+          const remainingKeys = prevState.slice(1);
+          return [...remainingKeys, generatedKey];
+        }
+
+        return [...prevState, generatedKey];
+      });
       // this is bad, but making a copy didn't work for some reason
-      events[key.keyCode] = key;
+      events[generatedKey.keyCode] = generatedKey;
       setEvents(events);
     });
 

--- a/lib/useKeyCode.js
+++ b/lib/useKeyCode.js
@@ -3,6 +3,20 @@ import { useRouter } from 'next/router';
 import { useKeyCode } from '../components/KeyCodeProvider';
 import { urlFriendly } from './urlFriendly';
 
+const getGeneratedKey = (e) => ({
+  key: e.key,
+  keyCode: e.keyCode,
+  which: e.which,
+  code: e.code,
+  location: e.location,
+  // Meta Keys
+  altKey: e.altKey,
+  ctrlKey: e.ctrlKey,
+  metaKey: e.metaKey,
+  shiftKey: e.shiftKey,
+  repeat: e.repeat,
+});
+
 export function useKeyWatcher() {
   // const [key, setKey] = useState();
   const { key, setKey, setEvents, events, setKeyHistory } = useKeyCode();
@@ -12,19 +26,7 @@ export function useKeyWatcher() {
     (e) => {
       e.preventDefault();
       router.push(`/for/${urlFriendly(e.key)}`);
-      const generatedKey = {
-        key: e.key,
-        keyCode: e.keyCode,
-        which: e.which,
-        code: e.code,
-        location: e.location,
-        // Meta Keys
-        altKey: e.altKey,
-        ctrlKey: e.ctrlKey,
-        metaKey: e.metaKey,
-        shiftKey: e.shiftKey,
-        repeat: e.repeat,
-      };
+      const generatedKey = getGeneratedKey(e);
       setKey(generatedKey);
       setKeyHistory((prevState) => {
         if (prevState.length === 0) return [generatedKey];

--- a/pages/for/[key].js
+++ b/pages/for/[key].js
@@ -148,20 +148,18 @@ export default function HomePage({ staticKey }) {
             <div className="card-main">
               <div className="main-description meta-keys">
                 {keyHistory.length > 0 &&
-                  keyHistory.map((kh) => {
-                    return (
-                      <button
-                        type="button"
-                        key={kh.keyCode}
-                        alt={`${kh.key} key`}
-                        onClick={() => setKey(kh)}
-                        className={`key ${kh.key ? 'pressed' : ''}`}
-                        style={{ background: 'inherit' }}
-                      >
-                        {kh.key}
-                      </button>
-                    );
-                  })}
+                  keyHistory.map((kh) => (
+                    <button
+                      type="button"
+                      key={kh.keyCode}
+                      alt={`${kh.key} key`}
+                      onClick={() => setKey(kh)}
+                      className={`key ${kh.key ? 'pressed' : ''}`}
+                      style={{ background: 'inherit' }}
+                    >
+                      {kh.key}
+                    </button>
+                  ))}
               </div>
             </div>
           </div>

--- a/pages/for/[key].js
+++ b/pages/for/[key].js
@@ -19,6 +19,58 @@ export default function HomePage({ staticKey }) {
   const key = generatedKey.key ? generatedKey : staticKey;
   const hasKeyToShow = key.key === undefined;
   const similarKeys = findSimilarKeys(key);
+
+  const renderMetaKey = (metaKey) => {
+    if (metaKey?.metaKey)
+      return (
+        <button
+          key={metaKey.keyCode}
+          type="button"
+          className="key pressed history"
+          alt="Meta Key"
+          onClick={() => setKey(metaKey)}
+        >
+          ⌘
+        </button>
+      );
+    if (metaKey?.shiftKey)
+      return (
+        <button
+          key={metaKey.keyCode}
+          type="button"
+          className="key pressed history"
+          alt="Shift Key"
+          onClick={() => setKey(metaKey)}
+        >
+          ⇧
+        </button>
+      );
+    if (metaKey?.altKey)
+      return (
+        <button
+          key={metaKey.keyCode}
+          type="button"
+          className="key pressed history"
+          alt="Alt / Option"
+          onClick={() => setKey(metaKey)}
+        >
+          ⌥
+        </button>
+      );
+    if (metaKey?.ctrlKey)
+      return (
+        <button
+          key={metaKey.keyCode}
+          type="button"
+          className="key pressed history"
+          alt="Control Key"
+          onClick={() => setKey(metaKey)}
+        >
+          ^
+        </button>
+      );
+  };
+
   return (
     <>
       <Head>
@@ -148,18 +200,21 @@ export default function HomePage({ staticKey }) {
             <div className="card-main">
               <div className="main-description meta-keys">
                 {keyHistory.length > 0 &&
-                  keyHistory.map((kh) => (
-                    <button
-                      type="button"
-                      key={kh.keyCode}
-                      alt={`${kh.key} key`}
-                      onClick={() => setKey(kh)}
-                      className={`key ${kh.key ? 'pressed' : ''}`}
-                      style={{ background: 'inherit' }}
-                    >
-                      {kh.key}
-                    </button>
-                  ))}
+                  keyHistory.map((kh) => {
+                    const isMeta = kh?.metaKey || kh?.shiftKey || kh?.altKey || kh?.ctrlKey;
+                    if (isMeta) return renderMetaKey(kh, setKey);
+                    return (
+                      <button
+                        type="button"
+                        key={kh.keyCode}
+                        alt={`${kh.key} Key`}
+                        className="key pressed history"
+                        onClick={() => setKey(kh)}
+                      >
+                        {kh.key}
+                      </button>
+                    );
+                  })}
               </div>
             </div>
           </div>

--- a/pages/for/[key].js
+++ b/pages/for/[key].js
@@ -12,7 +12,7 @@ import { keyCodesWithEvents } from '../../lib/keyCodesWithEvents';
 
 export default function HomePage({ staticKey }) {
   const { query } = useRouter();
-  const { key: generatedKey, history: keyHistory } = useKeyCode();
+  const { key: generatedKey, keyHistory, setKey } = useKeyCode();
   // Here we decide if we should show the code info from the users keyboard, or from our database of keys
   // The user's key is favourable, but if they are visiting the page directly, then we use the static key
   console.log(keyHistory);
@@ -145,7 +145,25 @@ export default function HomePage({ staticKey }) {
           </div>
           <div className="card item-unicode">
             <div className="card-header">History</div>
-            <div className="card-main">{keyHistory?.length}</div>
+            <div className="card-main">
+              <div className="main-description meta-keys">
+                {keyHistory.length > 0 &&
+                  keyHistory.map((kh) => {
+                    return (
+                      <button
+                        type="button"
+                        key={kh.keyCode}
+                        alt={`${kh.key} key`}
+                        onClick={() => setKey(kh)}
+                        className={`key ${kh.key ? 'pressed' : ''}`}
+                        style={{ background: 'inherit' }}
+                      >
+                        {kh.key}
+                      </button>
+                    );
+                  })}
+              </div>
+            </div>
           </div>
         </div>
         <div className="mobile-input" />
@@ -153,14 +171,14 @@ export default function HomePage({ staticKey }) {
 
       <span className="love">
         Made with love by
-        <a href="https://wesbos.com" target="_blank" rel="noopener">
+        <a href="https://wesbos.com" target="_blank" rel="noopener noreferrer">
           Wes Bos
         </a>{' '}
         — fork or suggest edits on
         <a
           href="https://github.com/wesbos/keycodes"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           GitHub
         </a>{' '}

--- a/style.css
+++ b/style.css
@@ -371,6 +371,13 @@ span.love a {
   box-shadow: 0 0 4px var(--button);
 }
 
+.key.history {
+  background: var(--card-background);
+  cursor: pointer;
+  min-height: 83px;
+  min-width: 72px;
+}
+
 small {
   color:#5f5f5f;
   font-size: 10px;


### PR DESCRIPTION
Implement History #307 

Hey @wesbos, thanks for the opportunity to contribute to this feature. Below is an outline of the things I implemented:

- Added logic to keep track of the last 4 keys pressed. I know in this [comment](https://github.com/wesbos/keycodes/issues/307#issuecomment-1013799799) you mentioned  "5 or so" but I found that having 4 keys aligned better with the Meta Keys card. However, this is an easy, one-line change if you want to modify that.
- Added logic to show key information when a user clicks on one of the recent keys. 
- No duplicates will be displayed in the history.
- Extracted the keydown listener into its own function and put it in a `useCallback`. This allowed for an easier way to add and remove the listener from within the `useEffect`.
- Added a little bit of CSS to polish up the history key display and made it so that the meta keys match the styles being applied in `MetaKey.js`
- Fixed an issue where the forward slash `/` would cause a 404.

I think that outlines everything but please let me know if you need me to clarify anything further. Thanks again for the opportunity and I look forward to hearing your feedback!