### PR TITLE
🐛 Fix URL in GitHub link

### DIFF
--- a/pages/for/[key].js
+++ b/pages/for/[key].js
@@ -228,7 +228,7 @@ export default function HomePage({ staticKey }) {
               <p>
                 This is the description we have created. Think it can be
                 improved?{' '}
-                <a href="github.com/wesbos/keycodes">PR us on GitHub</a>
+                <a href="https://github.com/wesbos/keycodes">PR us on GitHub</a>
               </p>
             </footer>
           </div>


### PR DESCRIPTION
The link was missing its protocol so was just being appended to the source URL leading to a 404